### PR TITLE
Show massage box using wxMessageOutputBest::Output() for all platforms

### DIFF
--- a/include/wx/apptrait.h
+++ b/include/wx/apptrait.h
@@ -88,6 +88,13 @@ public:
     // return true to suppress subsequent asserts, false to continue as before
     virtual bool ShowAssertDialog(const wxString& msg) = 0;
 
+    // Show the message box. Return false for non-GUI application (also return
+    // false under GTK when it's not initialized).
+    // The function added to use in wxMessageOutputBest::Output() because
+    // wxMessageBox() available only for GUI application.
+    virtual bool ShowMessageBox(const wxString& msg,
+                                const wxString& caption) = 0;
+
     // return true if fprintf(stderr) goes somewhere, false otherwise
     virtual bool HasStderr() = 0;
 
@@ -207,6 +214,8 @@ public:
     virtual wxRendererNative *CreateRenderer() wxOVERRIDE;
 
     virtual bool ShowAssertDialog(const wxString& msg) wxOVERRIDE;
+    virtual bool ShowMessageBox(const wxString& msg,
+                                const wxString& caption) wxOVERRIDE;
     virtual bool HasStderr() wxOVERRIDE;
 
     // the GetToolkitVersion for console application is always the same
@@ -246,6 +255,8 @@ public:
     virtual wxRendererNative *CreateRenderer() wxOVERRIDE;
 
     virtual bool ShowAssertDialog(const wxString& msg) wxOVERRIDE;
+    virtual bool ShowMessageBox(const wxString& msg,
+                                const wxString& caption) wxOVERRIDE;
     virtual bool HasStderr() wxOVERRIDE;
 
     virtual bool IsUsingUniversalWidgets() const wxOVERRIDE

--- a/include/wx/unix/apptrait.h
+++ b/include/wx/unix/apptrait.h
@@ -70,6 +70,9 @@ public:
     virtual bool ShowAssertDialog(const wxString& msg) wxOVERRIDE;
 #endif
 
+    virtual bool ShowMessageBox(const wxString& msg,
+                                const wxString& caption) wxOVERRIDE;
+
 #if wxUSE_SOCKETS
 
 #ifdef wxHAS_GUI_SOCKET_MANAGER

--- a/interface/wx/apptrait.h
+++ b/interface/wx/apptrait.h
@@ -133,5 +133,13 @@ public:
         Returns @true to suppress subsequent asserts, @false to continue as before.
     */
     virtual bool ShowAssertDialog(const wxString& msg) = 0;
+
+    /**
+        Shows the message with the specified message in GUI mode. Use internally
+        wxMessageBox() which is unavailable for the console application.
+        Returns @true if the message was showed, @false otherwise.
+    */
+    virtual bool ShowMessageBox(const wxString& msg,
+                                const wxString& caption) = 0;
 };
 

--- a/src/common/appbase.cpp
+++ b/src/common/appbase.cpp
@@ -938,6 +938,12 @@ bool wxConsoleAppTraitsBase::ShowAssertDialog(const wxString& msg)
     return wxAppTraitsBase::ShowAssertDialog(msg);
 }
 
+bool wxConsoleAppTraitsBase::ShowMessageBox(const wxString& WXUNUSED(msg),
+                                            const wxString& WXUNUSED(caption))
+{
+    return false;
+}
+
 bool wxConsoleAppTraitsBase::HasStderr()
 {
     // console applications always have stderr, even under Mac/Windows

--- a/src/common/appcmn.cpp
+++ b/src/common/appcmn.cpp
@@ -565,6 +565,13 @@ bool wxGUIAppTraitsBase::ShowAssertDialog(const wxString& msg)
     return wxAppTraitsBase::ShowAssertDialog(msg);
 }
 
+bool wxGUIAppTraitsBase::ShowMessageBox(const wxString& msg,
+                                        const wxString& caption)
+{
+    wxMessageBox(msg, caption, wxOK | wxICON_EXCLAMATION);
+    return true;
+}
+
 bool wxGUIAppTraitsBase::HasStderr()
 {
     // we consider that under Unix stderr always goes somewhere, even if the

--- a/src/gtk/utilsgtk.cpp
+++ b/src/gtk/utilsgtk.cpp
@@ -412,6 +412,16 @@ bool wxGUIAppTraits::ShowAssertDialog(const wxString& msg)
     return wxAppTraitsBase::ShowAssertDialog(msg);
 }
 
+bool wxGUIAppTraits::ShowMessageBox(const wxString& msg,
+                                    const wxString& caption)
+{
+    // Return false if GTK is not initialized.
+    if ( g_type_class_peek(GDK_TYPE_DISPLAY) == NULL )
+        return;
+
+    return wxGUIAppTraitsBase::ShowMessageBox(msg, caption);
+}
+
 #endif // __UNIX__
 
 #if defined(__UNIX__)


### PR DESCRIPTION
The function was showing the message box only under MSW. Support
wxMSGOUT_PREFER_MSGBOX frag for all platforms using wxMessageBox().